### PR TITLE
Added subscriber example. Close #2

### DIFF
--- a/rc_template_cpp/include/rc_template_cpp/rc_template_cpp.h
+++ b/rc_template_cpp/include/rc_template_cpp/rc_template_cpp.h
@@ -43,4 +43,9 @@ protected:
   string test_topic_pub_name_;
   ros::Publisher test_pub_;
   */
+
+  string test_topic_sub_name_;
+  ros::Subscriber test_sub_;
+
+  void testSubCb(const std_msgs::String::ConstPtr &msg);
 };

--- a/rc_template_cpp/include/rc_template_cpp/rc_template_cpp.h
+++ b/rc_template_cpp/include/rc_template_cpp/rc_template_cpp.h
@@ -3,6 +3,8 @@
 #include <rcomponent/rcomponent.h>
 #include <robotnik_msgs/State.h>
 
+#include <std_msgs/String.h>
+
 class RCTemplateCpp : public rcomponent::RComponent
 {
 public:

--- a/rc_template_cpp/include/rc_template_cpp/rc_template_cpp.h
+++ b/rc_template_cpp/include/rc_template_cpp/rc_template_cpp.h
@@ -44,8 +44,12 @@ protected:
   ros::Publisher test_pub_;
   */
 
+  /* Test Subscriber
   string test_topic_sub_name_;
   ros::Subscriber test_sub_;
+  */
 
+  /* Test Subscriber
   void testSubCb(const std_msgs::String::ConstPtr &msg);
+  */
 };

--- a/rc_template_cpp/src/rc_template_cpp.cpp
+++ b/rc_template_cpp/src/rc_template_cpp.cpp
@@ -21,8 +21,10 @@ int RCTemplateCpp::rosSetup()
         test_pub_ = pnh_.advertise<std_msgs::String>(test_topic_pub_name_, 1);
         */
 
+        /* Test Subscriber
         test_sub_ = pnh_.subscribe<std_msgs::String>(test_topic_sub_name_, 1,
                                                      &RCTemplateCpp::testSubCb, this);
+        */
     }
 }
 
@@ -43,8 +45,10 @@ void RCTemplateCpp::rosReadParams()
     readParam(pnh_, "test_topic_pub_name", test_topic_pub_name_, default_test_topic_pub_name, true);
     */
 
+    /* Test Subscriber   
     std::string default_test_topic_sub_name = "test_topic_name";
     readParam(pnh_, "test_topic_sub_name", test_topic_sub_name_, default_test_topic_sub_name, true);
+    */
 }
 
 void RCTemplateCpp::standbyState()
@@ -69,7 +73,9 @@ void RCTemplateCpp::failureState()
 {
 }
 
+/* Test Subscriber
 void RCTemplateCpp::testSubCb(const std_msgs::String::ConstPtr &msg)
 {
     RCOMPONENT_INFO("This should be print when a msg is received");
 }
+*/

--- a/rc_template_cpp/src/rc_template_cpp.cpp
+++ b/rc_template_cpp/src/rc_template_cpp.cpp
@@ -7,7 +7,6 @@ RCTemplateCpp::RCTemplateCpp(ros::NodeHandle h) : RComponent(h), nh_(h), pnh_("~
 
 RCTemplateCpp::~RCTemplateCpp()
 {
-    // TODO: create an example of subscriber
     // TODO: create an example of action client
     // TODO: create an example of action server
     // TODO: create an example of service client
@@ -21,6 +20,9 @@ int RCTemplateCpp::rosSetup()
         /* Test Publisher
         test_pub_ = pnh_.advertise<std_msgs::String>(test_topic_pub_name_, 1);
         */
+
+        test_sub_ = pnh_.subscribe<std_msgs::String>(test_topic_sub_name_, 1,
+                                                     &RCTemplateCpp::testSubCb, this);
     }
 }
 
@@ -40,6 +42,9 @@ void RCTemplateCpp::rosReadParams()
     std::string default_test_topic_pub_name = "test_topic_name";
     readParam(pnh_, "test_topic_pub_name", test_topic_pub_name_, default_test_topic_pub_name, true);
     */
+
+    std::string default_test_topic_sub_name = "test_topic_name";
+    readParam(pnh_, "test_topic_sub_name", test_topic_sub_name_, default_test_topic_sub_name, true);
 }
 
 void RCTemplateCpp::standbyState()
@@ -62,4 +67,9 @@ void RCTemplateCpp::emergencyState()
 
 void RCTemplateCpp::failureState()
 {
+}
+
+void RCTemplateCpp::testSubCb(const std_msgs::String::ConstPtr &msg)
+{
+    RCOMPONENT_INFO("This should be print when a msg is received");
 }

--- a/rc_template_cpp/src/rc_template_cpp.cpp
+++ b/rc_template_cpp/src/rc_template_cpp.cpp
@@ -1,5 +1,4 @@
 #include <rc_template_cpp/rc_template_cpp.h>
-#include <std_msgs/String.h>
 
 RCTemplateCpp::RCTemplateCpp(ros::NodeHandle h) : RComponent(h), nh_(h), pnh_("~")
 {


### PR DESCRIPTION
Used RCOMPONENT_INFO instead of ROS_INFO. It provides the namespace of the node, the function and the line where the ROS_INFO is being print.